### PR TITLE
fix: 🐛 unflatten with number as last key

### DIFF
--- a/__tests__/index.spec.ts
+++ b/__tests__/index.spec.ts
@@ -236,6 +236,26 @@ describe('buildTranslationFiles', () => {
 
   });
 
+  describe('unflat', () => {
+    const type = 'unflat', config = gConfig(type, { unflat: true });
+
+    beforeEach(() => fs.removeSync(`./__tests__/${type}/i18n`));
+
+    it('show work with unflat true', () => {
+      const expected = {
+        global: {
+          'a': {
+            '1': m,
+          }
+        }
+      };
+      buildTranslationFiles(config);
+
+      assertResult(type, expected.global);
+    });
+
+  });
+
 });
 
 

--- a/__tests__/unflat/1.ts
+++ b/__tests__/unflat/1.ts
@@ -1,0 +1,7 @@
+import { } from '@ngneat/transloco';
+
+class a {
+  /** t(a.1) */
+  method() {
+  }
+}

--- a/src/keysBuilder/buildTranslationFile.ts
+++ b/src/keysBuilder/buildTranslationFile.ts
@@ -15,7 +15,7 @@ export function buildTranslationFile(path: string, translation = {}, replace = f
 
   let newTranslation;
   if (getConfig().unflat) {
-    translation = flat.unflatten(translation);
+    translation = flat.unflatten(translation, { object: true });
   }
 
   if (replace) {


### PR DESCRIPTION
## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

```
[x] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] Other... Please describe:
```

## What is the current behavior?

When setting the keys manager to use nested object by setting the config _unflat_ to true, using a key where the last part is a number like in _key1.2_ the generated JSON is:

```json
{
  "key1": [
    null,
    null,
    "Missing value for 'key1.2'"
  ]
}
```

## What is the new behavior?

The observed behavior is related to the default handling of numbers in the npm module "flat" that is used by the keys manager. However that module can be instructed to prevent the automatic creation of arrays by setting its _object_ setting to true (see https://github.com/hughsk/flat#object).
Running with this setting the generated JSON looks like:

```json
{
  "key1": {
    "2": "Missing value for 'key1.2'"
  }
}
```

## Does this PR introduce a breaking change?

```
[ ] Yes
[x] No
```
