### PR TITLE
fix: 🐛 regex should look for full word template key only

### DIFF
--- a/__tests__/index.spec.ts
+++ b/__tests__/index.spec.ts
@@ -79,7 +79,7 @@ describe('buildTranslationFiles', () => {
     beforeEach(() => fs.removeSync(`./__tests__/${type}/i18n`));
 
     it('should work with ngTemplate', () => {
-      let expected = gKeys(35);
+      let expected = gKeys(36);
       buildTranslationFiles(config);
       assertResult(type, expected);
     });

--- a/__tests__/ngTemplate/5.html
+++ b/__tests__/ngTemplate/5.html
@@ -1,0 +1,7 @@
+<ng-template transloco let-t>
+  <h1>ddsds</h1>
+  <button (click)="test('36.1')" (blur)="t('36')">{{ test('37.1') }}</button>
+  {{test('38.1')}} {{
+test('39.1')
+}}
+</ng-template>

--- a/src/regexs.ts
+++ b/src/regexs.ts
@@ -7,7 +7,7 @@
 import { sanitizeForRegex } from './helpers/sanitizeForRegex';
 
 export const regexs = {
-  templateKey: varName => new RegExp(`${varName}\\((?![^,)+]*\\+)('|")(?<key>[^)"']*?)\\1`, 'g'),
+  templateKey: varName => new RegExp(`\\b${varName}\\((?![^,)+]*\\+)('|")(?<key>[^)"']*?)\\1`, 'g'),
   directive: () => new RegExp(`\\stransloco\\s*=\\s*("|')(?<key>[^]+?)\\1`, 'g'),
   directiveTernary: () => new RegExp(`\\s\\[transloco\\]\\s*=\\s*("|')[^"'?]*\\?(?<key>[^]+?)\\1`, 'g'),
   pipe: () =>


### PR DESCRIPTION
## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

```
[x] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] Other... Please describe:
```

## What is the current behavior?

Transloco uses "t" as default marker to extract keys where it finds some string like `t('blah')`. Unfortunately it also "detects" hits if you use method calls where the name of the method ends in "t" (or whatever you are using as marker) like `<button (click)="doSort('abc')">Push me</button>`.

## What is the new behavior?

The regex to extract keys will only return keys where the marker is not at the end of a word but represents the full name.

## Does this PR introduce a breaking change?

```
[ ] Yes
[x] No
```
