### PR TITLE
feat: 🎸 support ternary operator in structural directive

### DIFF
--- a/README.md
+++ b/README.md
@@ -256,11 +256,14 @@ The extracted keys for the code above will be:
 }
 ```
 
-- Supports **static** ternary operators:
+- Supports **static** and **structural directive** ternary operators:
 
 ```html
 <comp [placeholder]="condition ? 'keyOne' : 'keyTwo' | transloco"></comp>
 <h1>{{ condition ? 'keyOne' : 'keyTwo' | transloco }}</h1>
+
+<comp *transloco="let t; read: 'ternary'"></comp>
+<h1>{{ t(condition ? 'keyOne' : 'keyTwo') }}</h1>
 ```
 
 ## 🕵️‍ Keys Detective

--- a/__tests__/buildTranslationFiles.spec.ts
+++ b/__tests__/buildTranslationFiles.spec.ts
@@ -164,12 +164,15 @@ describe('buildTranslationFiles', () => {
       const expected = {
         global: {
           ...gKeys(3),
-          ...gKeys(21, 'site-header.navigation.route'),
+          ...gKeys(23, 'site-header.navigation.route'),
           ...gKeys(5, 'site-header.navigation'),
           ...gKeys(10, 'right-pane.actions'),
           ...gKeys(1, 'templates.translations'),
           ...gKeys(3, 'nested.translation'),
-          ...gKeys(3, 'some.other.nested.that-is-tested')
+          ...gKeys(3, 'some.other.nested.that-is-tested'),
+          ...gKeys(9, 'ternary.nested'),
+          ...gKeys(2, 'nested'),
+          ...gKeys(2, 'site-header.navigation.route.nested')
         },
         todos: {
           ...gKeys(2, 'numbers')

--- a/__tests__/read/1.html
+++ b/__tests__/read/1.html
@@ -1,3 +1,14 @@
+<ng-container *transloco="let t; read: 'ternary.nested'">
+  <p>{{t('1')}}</p>
+  <p>{{t(condition ? '2' : '3')}}</p>
+  <p>{{t(condition ? '4' : "5")}}</p>
+  <p>{{t(condition ? "6" : '7')}}</p>
+  <p>{{t(condition ? "8" : "9")}}</p>
+  <p>{{t(condition ? condition2 ? "10" : "11" : "12")}}</p>
+  <p>{{ should ? not : extract }}</p>
+  <p>{{ also ? 'th' : 'is' }}</p>
+</ng-container>
+
 <ng-container *transloco="let t; read: 'site-header.navigation.route'">
   <dato-dialog-header class="py-22">
     <div class="d-flex-row">
@@ -10,6 +21,7 @@
       <div class="left py-15 px-10">
         <div class="ml-5 d-flex-row align-space-between-center">
           <div>{{ t('d' + 4)}}</div>
+          <p>{{ t(condition ? "22" : "23" )}}</p>
           <div datoColor="primary-400" datoFont="note-bold">{{ t('1') }}</div>
           <div *ngIf="isGroupMode" class="d-flex">
             <dato-icon-button datoType="secondary" datoSize="md" datoIcon="x"
@@ -41,6 +53,12 @@
         </mat-menu>
         <div *ngIf="!hasFilter; else filtersView" class="mt-15" datoFont="note" datoColor="primary-400">
           {{t("5", {name: "avo"})}}
+        </div>
+        <div *transloco="let p; read: 'nested'">
+          <p>{{ p(condition ? '1' : "2") }}</p>
+        </div>
+        <div *transloco="let k; read: 'site-header.navigation.route.nested'">
+          <p>{{ k(condition ? '1' : "2") }}</p>
         </div>
         <ng-template #filtersView>
           <div>

--- a/src/keysBuilder/getStructuralDirectiveBasedKeys.ts
+++ b/src/keysBuilder/getStructuralDirectiveBasedKeys.ts
@@ -31,11 +31,19 @@ export function getStructuralDirectiveBasedKeys(
 
   if (varName) {
     const keyRegex = regexs.templateKey(varName);
+    const ternaryRegex = regexs.structuralDirectiveTernary(varName);
     let keySearch = keyRegex.exec(matchedStr);
+    let ternarySearch = ternaryRegex.exec(matchedStr);
 
     while (keySearch) {
       translationKeys.push(keySearch.groups.key);
       keySearch = keyRegex.exec(matchedStr);
+    }
+
+    while (ternarySearch) {
+      const { keyA, keyB } = ternarySearch.groups;
+      translationKeys.push(keyA, keyB);
+      ternarySearch = ternaryRegex.exec(matchedStr);
     }
   }
 

--- a/src/regexs.ts
+++ b/src/regexs.ts
@@ -10,6 +10,8 @@ export const regexs = {
   templateKey: varName => new RegExp(`\\b${varName}\\((?![^,)+]*\\+)('|")(?<key>[^)"']*?)\\1`, 'g'),
   directive: () => new RegExp(`\\stransloco\\s*=\\s*("|')(?<key>[^]+?)\\1`, 'g'),
   directiveTernary: () => new RegExp(`\\s\\[transloco\\]\\s*=\\s*("|')[^"'?]*\\?(?<key>[^]+?)\\1`, 'g'),
+  structuralDirectiveTernary: varName =>
+    new RegExp(`\\b${varName}\\([^?}]+\\?\\s*("|')(?<keyA>[^'":]+)\\1\\s*:\\s*("|')(?<keyB>[^'"]*)\\3\\s*\\)`, 'g'),
   pipe: () =>
     /(?:(?:\{\{(?![^^}\|+]*\+)[^}\|'"]*)|(?:\[[^\]]*\]=(?:"|')(?![^'"+]*\+)[^'"]*))('|")(?<key>[^'"\[>=]*?)\1[^'"\|\[}]*(?:('|")(?<key2>[^"'\[>]*?)\3)?[^\|}>\[]*?\|[^}>\[]*?transloco/g,
   tsCommentsSection: () => /\/\*\*[^]+?\*\//g,


### PR DESCRIPTION
Closes: 41

## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/ngneat/transloco/blob/master/CONTRIBUTING.md#commit
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features) (I think it was there already)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

```
[ ] Bugfix
[x] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] Other... Please describe:
```

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: #41 

## What is the new behavior?
Key Manager will parse the following and add it to json.
`<p>{{t(condition ? 'yin' : 'yang')}}</p>`
It won't work with multiply nested ternary operators.

## Does this PR introduce a breaking change?

```
[ ] Yes
[x] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information

I'm not good in regexes so that for sure can be optimized. Also Im not sure if this is even right way to do this.
