### PR TITLE
Workspace Config Path

### DIFF
--- a/__tests__/resolveProjectBasePath.spec.ts
+++ b/__tests__/resolveProjectBasePath.spec.ts
@@ -3,8 +3,8 @@ import * as fs from 'fs-extra';
 import { resolveProjectBasePath } from '../src/helpers/resolveProjectBasePath';
 
 describe('resolveProjectBasePath', () => {
-  function addAngularConfig() {
-    fs.writeJsonSync('angular.json', {
+  function addAngularConfig(configFile: string = 'angular.json') {
+    fs.writeJsonSync(configFile, {
       defaultProject: 'defaultProject',
       projects: {
         defaultProject: { projectType: 'application', sourceRoot: 'testDir' },
@@ -13,32 +13,37 @@ describe('resolveProjectBasePath', () => {
     });
   }
 
-  function removeAngularConfig() {
-    fs.removeSync('angular.json');
+  function removeAngularConfig(configFile: string = 'angular.json') {
+    fs.removeSync(configFile);
   }
 
   it('should return the default "src"', () => {
     expect(resolveProjectBasePath().projectBasePath).toBe('src');
   });
 
-  describe('with angular config', () => {
-    beforeAll(() => {
-      addAngularConfig();
-    });
-    afterAll(() => {
-      removeAngularConfig();
-    });
+  describe.each([
+    [undefined, 'angular.json'],
+    ['workspace.json', 'workspace.json']
+  ])('with workspace config as %s', (workspaceConfigPath, configFileName) => {
+    describe('with angular config', () => {
+      beforeAll(() => {
+        addAngularConfig(configFileName);
+      });
+      afterAll(() => {
+        removeAngularConfig(configFileName);
+      });
 
-    it('should return the source root of the default project', () => {
-      const { projectBasePath, projectType } = resolveProjectBasePath();
-      expect(projectBasePath).toBe('testDir');
-      expect(projectType).toBe('application');
-    });
+      it('should return the source root of the default project', () => {
+        const { projectBasePath, projectType } = resolveProjectBasePath(undefined, workspaceConfigPath);
+        expect(projectBasePath).toBe('testDir');
+        expect(projectType).toBe('application');
+      });
 
-    it('should return the source root of the given project', () => {
-      const { projectBasePath, projectType } = resolveProjectBasePath('myProject');
-      expect(projectBasePath).toBe('myRoot');
-      expect(projectType).toBe('library');
+      it('should return the source root of the given project', () => {
+        const { projectBasePath, projectType } = resolveProjectBasePath('myProject', workspaceConfigPath);
+        expect(projectBasePath).toBe('myRoot');
+        expect(projectType).toBe('library');
+      });
     });
   });
 });

--- a/src/helpers/resolveConfig.ts
+++ b/src/helpers/resolveConfig.ts
@@ -8,13 +8,16 @@ import { getScopes } from '../keysBuilder/scopes';
 import { messages } from '../messages';
 import { Config } from '../types';
 
-import { devlog } from './logger';
 import { isDirectory } from './isDirectory';
+import { devlog } from './logger';
 import { resolveProjectBasePath } from './resolveProjectBasePath';
 import { updateScopesMap } from './updateScopesMap';
 
 export function resolveConfig(inlineConfig: Config): Config {
-  const { projectBasePath, projectType } = resolveProjectBasePath(inlineConfig.project);
+  const { projectBasePath, projectType } = resolveProjectBasePath(
+    inlineConfig.project,
+    inlineConfig.workspaceConfigPath
+  );
   const defaults = defaultConfig(projectType);
   const fileConfig = getConfig(inlineConfig.config || projectBasePath);
   const userConfig = { ...flatFileConfig(fileConfig), ...inlineConfig };

--- a/src/helpers/resolveProjectBasePath.ts
+++ b/src/helpers/resolveProjectBasePath.ts
@@ -1,13 +1,17 @@
+import chalk from 'chalk';
 import { cosmiconfigSync } from 'cosmiconfig';
 
 import { ProjectType } from '../defaultConfig';
 
 type ProjectBasePath = { projectBasePath: string; projectType: ProjectType };
 
-export function resolveProjectBasePath(projectName?: string): ProjectBasePath {
-  const result = cosmiconfigSync('angular', { searchPlaces: ['angular.json', '.angular.json'] }).search();
+const defaultWorkspaceConfigPaths = ['angular.json', '.angular.json'];
+
+export function resolveProjectBasePath(projectName?: string, workspaceConfigPath?: string): ProjectBasePath {
+  const searchPlaces = workspaceConfigPath ? [workspaceConfigPath] : defaultWorkspaceConfigPaths;
+  const result = cosmiconfigSync('angular', { searchPlaces }).search();
   let sourceRoot = 'src';
-  let projectType;
+  let projectType: ProjectType;
   const config = result?.config;
   if (config) {
     projectName = projectName || config.defaultProject;
@@ -16,6 +20,12 @@ export function resolveProjectBasePath(projectName?: string): ProjectBasePath {
       sourceRoot = project.sourceRoot;
       projectType = project.projectType;
     }
+  } else {
+    console.log(
+      chalk.black.bgRed(
+        `Unable to load workspace config from ${searchPlaces.join(', ')}. Defaulting source root to '${sourceRoot}'`
+      )
+    );
   }
 
   return { projectBasePath: sourceRoot, projectType };

--- a/src/types.ts
+++ b/src/types.ts
@@ -18,6 +18,7 @@ export type Config = {
   sort?: boolean;
   unflat?: boolean;
   command?: 'extract' | 'find';
+  workspaceConfigPath?: string;
 };
 
 export type ExtractionResult = {


### PR DESCRIPTION
This PR adds the capability to define the workspace configuration path if the file name is not `angular.json`.

Closes #72 