### PR TITLE
fix: 🐛 allow extraction of template strings with ", ' and ) in the key

### DIFF
--- a/src/regexs.ts
+++ b/src/regexs.ts
@@ -7,7 +7,7 @@
 import { sanitizeForRegex } from './helpers/sanitizeForRegex';
 
 export const regexs = {
-  templateKey: varName => new RegExp(`\\b${varName}\\((?![^,)+]*\\+)\\s*('|")(?<key>[^)"']*?)\\1`, 'g'),
+  templateKey: varName => new RegExp(`\\b${varName}\\((?![^,)+]*\\+)\\s*('|")(?<key>.*?)\\1`, 'g'),
   directive: () => new RegExp(`\\stransloco\\s*=\\s*("|')(?<key>[^]+?)\\1`, 'g'),
   directiveTernary: () => new RegExp(`\\s\\[transloco\\]\\s*=\\s*("|')[^"'?]*\\?(?<key>[^]+?)\\1`, 'g'),
   structuralDirectiveTernary: varName =>


### PR DESCRIPTION
This should fix #87.

I wonder if I'm making the regex too loose, but I'm confident as it is using greedy matching and it works on a larger project of mine, as well as the tests pass.