### PR TITLE
fix: 🐛 use webpack 5's modified file list when available

### DIFF
--- a/src/webpack-plugin.ts
+++ b/src/webpack-plugin.ts
@@ -30,7 +30,7 @@ export class TranslocoExtractKeysWebpackPlugin {
       }
 
       const keysExtractions = { html: [], ts: [] };
-      const files = Object.keys(comp.watchFileSystem.watcher.mtimes);
+      const files = comp.modifiedFiles || Object.keys(comp.watchFileSystem.watcher.mtimes);
 
       for (const file of files) {
         let fileType;


### PR DESCRIPTION
The private API for Watchpack has changed with Webpack 5. Instead of
using watchFileSystem.watcher.mtimes, the modified files can be accessed
directly from compiler.modifiedFiles. This change will fall back to
watcher.mtimes if the Webpack 5 API is falsy.

✅ Closes: #98