### PR TITLE
feat: 🎸 support optional newline at end of translation files

### DIFF
--- a/README.md
+++ b/README.md
@@ -420,6 +420,13 @@ transloco-keys-manager extract --replace
 transloco-keys-manager extract -r
 ```
 
+- `addEofNewline`: Add a newline character to the end of translation files when writing (default is to add nothing)
+
+```
+transloco-keys-manager extract --add-eof-newline
+transloco-keys-manager extract -n
+```
+
 - `addMissingKeys`: Add missing keys that were found by the detective (defaults to `false`)
 
 ```
@@ -466,6 +473,7 @@ module.exports = {
     replace?: boolean;
     defaultValue?: string | undefined;
     unflat?: boolean;
+    addEofNewline?: boolean;
   };
 }
 ```

--- a/__tests__/addEofNewline/1.ts
+++ b/__tests__/addEofNewline/1.ts
@@ -1,0 +1,6 @@
+import {} from '@ngneat/transloco';
+
+class a {
+  /** t(a.1) */
+  method() {}
+}

--- a/__tests__/buildTranslationFiles.spec.ts
+++ b/__tests__/buildTranslationFiles.spec.ts
@@ -420,4 +420,37 @@ describe('buildTranslationFiles', () => {
       assertResult(type, expected);
     });
   });
+
+  describe('addEofNewline', () => {
+    function assertEofChar(type: string, hasNewline: boolean, path?: string) {
+      const translation = fs.readFileSync(`./${sourceRoot}/${type}/i18n/${path || ''}en.json`, { encoding: 'utf-8' });
+      const maybeNewline = hasNewline ? '\n' : '';
+      expect(translation).toMatch(new RegExp(`}${maybeNewline}$`));
+    }
+
+    const type = 'addEofNewline';
+
+    beforeEach(() => removeI18nFolder(type));
+
+    it('should not add an eof newline if undefined', () => {
+      const config = gConfig(type);
+
+      buildTranslationFiles(config);
+      assertEofChar(type, false);
+    });
+
+    it('should not add an eof newline if false', () => {
+      const config = gConfig(type, { addEofNewline: false });
+
+      buildTranslationFiles(config);
+      assertEofChar(type, false);
+    });
+
+    it('should add an eof newline if true', () => {
+      const config = gConfig(type, { addEofNewline: true });
+
+      buildTranslationFiles(config);
+      assertEofChar(type, true);
+    });
+  });
 });

--- a/src/cliOptions.ts
+++ b/src/cliOptions.ts
@@ -34,6 +34,12 @@ export const optionDefinitions = [
   },
   { name: 'sort', alias: 's', type: Boolean, description: `Sort keys using the sort() method` },
   { name: 'unflat', alias: 'u', type: Boolean, description: `Unflat the translation file` },
+  {
+    name: 'add-eof-newline',
+    alias: 'n',
+    type: Boolean,
+    description: 'Add a newline character to the end of translation files when writing (default is to add nothing)'
+  },
   { name: 'default-value', alias: 'd', type: String, description: `The default value of a generated key` },
   {
     name: 'add-missing-keys',

--- a/src/helpers/writeFile.ts
+++ b/src/helpers/writeFile.ts
@@ -2,6 +2,6 @@ import * as fs from 'fs';
 
 import { stringify } from './stringify';
 
-export function writeFile(fileName: string, content: object) {
-  return fs.writeFileSync(fileName, stringify(content), { encoding: 'UTF-8' });
+export function writeFile(fileName: string, content: object, addEofNewline = false) {
+  return fs.writeFileSync(fileName, stringify(content) + (addEofNewline ? '\n' : ''), { encoding: 'UTF-8' });
 }

--- a/src/keysBuilder.ts
+++ b/src/keysBuilder.ts
@@ -33,6 +33,7 @@ export function buildTranslationFiles(inlineConfig: Config) {
     scopes: config.scopes,
     langs: config.langs,
     outputPath: config.output,
-    replace: config.replace
+    replace: config.replace,
+    addEofNewline: config.addEofNewline
   });
 }

--- a/src/keysBuilder/buildTranslationFile.ts
+++ b/src/keysBuilder/buildTranslationFile.ts
@@ -10,7 +10,12 @@ export type FileAction = {
   type: 'new' | 'modified';
 };
 
-export function buildTranslationFile(path: string, translation = {}, replace = false): FileAction {
+export function buildTranslationFile(
+  path: string,
+  translation = {},
+  replace = false,
+  addEofNewline = false
+): FileAction {
   const currentTranslation = fsExtra.readJsonSync(path, { throws: false }) || {};
   const action: FileAction = { type: currentTranslation ? 'modified' : 'new', path };
 
@@ -25,7 +30,7 @@ export function buildTranslationFile(path: string, translation = {}, replace = f
     newTranslation = mergeDeep(translation, currentTranslation);
   }
 
-  fsExtra.outputFileSync(path, stringify(newTranslation));
+  fsExtra.outputFileSync(path, stringify(newTranslation) + (addEofNewline ? '\n' : ''));
 
   return action;
 }

--- a/src/keysBuilder/createTranslationFiles.ts
+++ b/src/keysBuilder/createTranslationFiles.ts
@@ -11,9 +11,10 @@ type Params = {
   outputPath: string;
   replace: boolean;
   scopes: Scopes;
+  addEofNewline: boolean;
 };
 
-export function createTranslationFiles({ scopeToKeys, langs, outputPath, replace, scopes }: Params) {
+export function createTranslationFiles({ scopeToKeys, langs, outputPath, replace, scopes, addEofNewline }: Params) {
   const logger = getLogger();
 
   const scopeFiles = buildScopeFilePaths({ aliasToScope: scopes.aliasToScope, langs, outputPath });
@@ -21,11 +22,11 @@ export function createTranslationFiles({ scopeToKeys, langs, outputPath, replace
   const actions: FileAction[] = [];
 
   for (const { path } of globalFiles) {
-    actions.push(buildTranslationFile(path, scopeToKeys.__global, replace));
+    actions.push(buildTranslationFile(path, scopeToKeys.__global, replace, addEofNewline));
   }
 
   for (const { path, scope } of scopeFiles) {
-    actions.push(buildTranslationFile(path, scopeToKeys[scope], replace));
+    actions.push(buildTranslationFile(path, scopeToKeys[scope], replace, addEofNewline));
   }
 
   const newFiles = actions.filter(action => action.type === 'new');

--- a/src/keysBuilder/generateKeys.ts
+++ b/src/keysBuilder/generateKeys.ts
@@ -55,7 +55,7 @@ export function generateKeys({ translationPath, scopeToKeys, config }: Params) {
     }
     for (const filePath of files) {
       const translation = readFile(filePath, { parse: true });
-      writeFile(filePath, mergeDeep({}, keys, translation));
+      writeFile(filePath, mergeDeep({}, keys, translation), config.addEofNewline);
     }
   }
 }

--- a/src/keysDetective.ts
+++ b/src/keysDetective.ts
@@ -29,6 +29,7 @@ export function findMissingKeys(inlineConfig: Config) {
     scopeToKeys: result.scopeToKeys,
     translationPath: config.translationsPath,
     addMissingKeys: config.addMissingKeys,
-    emitErrorOnExtraKeys: config.emitErrorOnExtraKeys
+    emitErrorOnExtraKeys: config.emitErrorOnExtraKeys,
+    addEofNewline: config.addEofNewline
   });
 }

--- a/src/keysDetective/compareKeysToFiles.ts
+++ b/src/keysDetective/compareKeysToFiles.ts
@@ -17,9 +17,16 @@ type Params = {
   translationPath: string;
   addMissingKeys: boolean;
   emitErrorOnExtraKeys: boolean;
+  addEofNewline: boolean;
 };
 
-export function compareKeysToFiles({ scopeToKeys, translationPath, addMissingKeys, emitErrorOnExtraKeys }: Params) {
+export function compareKeysToFiles({
+  scopeToKeys,
+  translationPath,
+  addMissingKeys,
+  emitErrorOnExtraKeys,
+  addEofNewline
+}: Params) {
   const logger = getLogger();
   logger.startSpinner(`${messages.checkMissing} ✨`);
 
@@ -90,7 +97,7 @@ export function compareKeysToFiles({ scopeToKeys, translationPath, addMissingKey
           }
         }
 
-        addMissingKeys && writeFile(filePath, translation);
+        addMissingKeys && writeFile(filePath, translation, addEofNewline);
       }
     }
   }

--- a/src/types.ts
+++ b/src/types.ts
@@ -17,6 +17,7 @@ export type Config = {
   marker?: string;
   sort?: boolean;
   unflat?: boolean;
+  addEofNewline?: boolean;
   command?: 'extract' | 'find';
 };
 


### PR DESCRIPTION
This adds a boolean flag to terminate files with a newline character,
preventing the illusion of extracted keys when only the EOF character
changed.

✅ Closes: #79