### PR TITLE
TypeError: (0 , transloco_utils_1.getConfig) is not a function

### DIFF
--- a/src/keys-detective/compare-keys-to-files.ts
+++ b/src/keys-detective/compare-keys-to-files.ts
@@ -1,4 +1,4 @@
-import { getConfig as translocoConfig } from '@ngneat/transloco-utils';
+import { getGlobalConfig } from '@ngneat/transloco-utils';
 import { applyChange, diff } from 'deep-diff';
 import { flatten } from 'flat';
 import * as glob from 'glob';
@@ -33,7 +33,7 @@ export function compareKeysToFiles({
   const translationFiles = getTranslationFilesPath(translationPath);
 
   let result = [];
-  const scopePaths = translocoConfig().scopePathMap || {};
+  const scopePaths = getGlobalConfig().scopePathMap || {};
   for (const [scope, path] of Object.entries(scopePaths)) {
     const keys = scopeToKeys[scope];
     if (keys) {

--- a/src/webpack-plugin/generate-keys.ts
+++ b/src/webpack-plugin/generate-keys.ts
@@ -1,4 +1,4 @@
-import { TranslocoConfig } from '@ngneat/transloco-utils';
+import { TranslocoGlobalConfig } from '@ngneat/transloco-utils';
 import { unflatten } from 'flat';
 import * as glob from 'glob';
 import * as nodePath from 'path';
@@ -10,7 +10,7 @@ import { mergeDeep } from '../utils/object.utils';
 type Params = {
   translationPath: string;
   scopeToKeys: ScopeMap;
-  config: Config & TranslocoConfig;
+  config: Config & TranslocoGlobalConfig;
 };
 
 function filterLangs(config: Params['config']) {


### PR DESCRIPTION
 "transloco-keys-manager find" throws TypeError: (0 , transloco_utils_1.getConfig) is not a function

@ngneat/transloco-utils  getConfig() was removed in commit a810ada00bdf601152476375473db7ea61303bb4 , use getGlobalConfig() instead

## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/ngneat/transloco/blob/master/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

```
[x] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] Other... Please describe:
```

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: N/A

## What is the new behavior?

## Does this PR introduce a breaking change?

```
[ ] Yes
[x] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information
