### PR TITLE
feat: 🎸 detect keys in pipes args

### DIFF
--- a/__tests__/buildTranslationFiles.spec.ts
+++ b/__tests__/buildTranslationFiles.spec.ts
@@ -97,7 +97,7 @@ describe('buildTranslationFiles', () => {
           '49.50.51.52': defaultValue,
           ...generateKeys({ start: 53, end: 62 }),
           '63.64.65': defaultValue,
-          ...generateKeys({ start: 66, end: 67 }),
+          ...generateKeys({ start: 66, end: 70 }),
         };
         [
           'Restore Options',

--- a/__tests__/buildTranslationFiles.spec.ts
+++ b/__tests__/buildTranslationFiles.spec.ts
@@ -139,7 +139,7 @@ describe('buildTranslationFiles', () => {
       beforeEach(() => removeI18nFolder(type));
 
       it('should work with ngContainer', () => {
-        let expected = generateKeys({ end: 39 });
+        let expected = generateKeys({ end: 46 });
         // See https://github.com/ngneat/transloco-keys-manager/issues/87
         expected["Bob's Burgers"] =
           expected['another(test)'] =

--- a/__tests__/ngContainer/3.html
+++ b/__tests__/ngContainer/3.html
@@ -22,6 +22,13 @@
       </my-comp>
       <p ds="{{ '39' | transloco}}">dskdsds</p>
 
+      <ul>
+        <li>{{ variable | another : t('40') }}</li>
+        <li>{{ variable | another : t('41') | lowercase }}</li>
+        <li>{{ variable | another : {a: t('42')} | lowercase }}</li>
+        <li>{{ t('43') | another: t('44') }}</li>
+        <li>{{ t('45') | another: ('46' | transloco) }}</li>
+      </ul>
     </ng-container>
   </ng-container>
 </ng-container>

--- a/__tests__/pipe/6.html
+++ b/__tests__/pipe/6.html
@@ -37,3 +37,6 @@
 
 {{ '66' | transloco }}
 {{ condition ? '67' | transloco : 'dont take' }}
+
+{{ var | another : {foo: '68' | transloco} | other : ('69' | transloco) }}
+{{ var | another : ('70' | transloco) | lowercase }}

--- a/src/keys-builder/template/pipe.extractor.ts
+++ b/src/keys-builder/template/pipe.extractor.ts
@@ -12,6 +12,7 @@ import {
   isElement,
   isInterpolation,
   isLiteralExpression,
+  isLiteralMap,
   isTemplate,
   parseTemplate,
 } from './utils';
@@ -64,6 +65,10 @@ function getPipeValuesFromAst(ast: AST): AST[] {
 
       return [pipe.exp];
     }
+  } else if (isBindingPipe(ast)) {
+    exp = [...ast.args, ast.exp];
+  } else if (isLiteralMap(ast)) {
+    exp = ast.values;
   } else if (isInterpolation(ast)) {
     exp = ast.expressions;
   } else if (isConditionalExpression(ast)) {

--- a/src/keys-builder/template/structural-directive.extractor.ts
+++ b/src/keys-builder/template/structural-directive.extractor.ts
@@ -48,7 +48,7 @@ export function traverse(
   config: TemplateExtractorConfig
 ) {
   for (const node of nodes) {
-    let methodUsages = [] as ContainerMetaData[];
+    let methodUsages: ContainerMetaData[] = [];
 
     if (isBoundText(node)) {
       const { expressions } = (node.value as ASTWithSource)

--- a/src/keys-builder/template/structural-directive.extractor.ts
+++ b/src/keys-builder/template/structural-directive.extractor.ts
@@ -30,7 +30,7 @@ import {
 } from './utils';
 
 interface ContainerMetaData {
-  exp?: any;
+  exp?: AST;
   name: string;
   read?: string;
   /* We need to keep the element's span since we might have several method declarations with the same name */

--- a/src/keys-builder/template/structural-directive.extractor.ts
+++ b/src/keys-builder/template/structural-directive.extractor.ts
@@ -28,6 +28,7 @@ import {
 } from './utils';
 
 interface ContainerMetaData {
+  exp?: any;
   name: string;
   read?: string;
   /* We need to keep the element's span since we might have several method declarations with the same name */
@@ -45,7 +46,7 @@ export function traverse(
   config: TemplateExtractorConfig
 ) {
   for (const node of nodes) {
-    let methodUsages = [];
+    let methodUsages = [] as ContainerMetaData[];
 
     if (isBoundText(node)) {
       const { expressions } = (node.value as ASTWithSource)
@@ -84,7 +85,10 @@ function unwrapExpression(exp: AST): AST {
   return isBindingPipe(exp) ? unwrapExpression(exp.exp) : exp;
 }
 
-function getMethodUsages(expressions: AST[], containers: ContainerMetaData[]) {
+function getMethodUsages(
+  expressions: AST[],
+  containers: ContainerMetaData[]
+): ContainerMetaData[] {
   return expressions
     .map((exp) => unwrapExpression(exp))
     .filter((exp) => isTranslocoMethod(exp, containers))
@@ -128,7 +132,7 @@ function resolveMetadata(node: TmplAstTemplate): ContainerMetaData[] {
   /*
    * An ngTemplate element might have more then once implicit variables, we need to capture all of them.
    * */
-  let metadata: Omit<ContainerMetaData, 'spanOffset'>[];
+  let metadata: Omit<ContainerMetaData, 'spanOffset' | 'exp'>[];
   if (isNgTemplateTag(node)) {
     const implicitVars = node.variables.filter((attr) => !attr.value);
     let read = node.attributes.find(isReadAttr)?.value;
@@ -164,7 +168,7 @@ function resolveMetadata(node: TmplAstTemplate): ContainerMetaData[] {
 }
 
 function addKeysFromAst(
-  expressions: Array<{ exp: AST } & Pick<ContainerMetaData, 'read'>>,
+  expressions: Array<Pick<ContainerMetaData, 'exp' | 'read'>>,
   config: ExtractorConfig
 ): void {
   for (const { exp, read } of expressions) {

--- a/src/keys-builder/template/structural-directive.extractor.ts
+++ b/src/keys-builder/template/structural-directive.extractor.ts
@@ -100,8 +100,7 @@ function getMethodUsages(
   containers: ContainerMetaData[]
 ): ContainerMetaData[] {
   return expressions
-    .map(unwrapMethodCalls)
-    .flat()
+    .flatMap(unwrapMethodCalls)
     .filter((exp) => isTranslocoMethod(exp, containers))
     .map((exp: MethodCall) => {
       return {

--- a/src/keys-builder/template/structural-directive.extractor.ts
+++ b/src/keys-builder/template/structural-directive.extractor.ts
@@ -78,7 +78,7 @@ export function traverse(
 }
 
 class MethodCallUnwrapper extends RecursiveAstVisitor {
-  public expressions: MethodCall[] = [];
+  expressions: MethodCall[] = [];
 
   override visitMethodCall(method: MethodCall, context: any) {
     this.expressions.push(method);

--- a/src/keys-builder/template/utils.ts
+++ b/src/keys-builder/template/utils.ts
@@ -2,6 +2,7 @@ import {
   BindingPipe,
   Conditional,
   Interpolation,
+  LiteralMap,
   LiteralPrimitive,
   MethodCall,
   parseTemplate as ngParseTemplate,
@@ -58,6 +59,10 @@ export function isLiteralExpression(
   expression: unknown
 ): expression is LiteralPrimitive {
   return expression instanceof LiteralPrimitive;
+}
+
+export function isLiteralMap(expression: unknown): expression is LiteralMap {
+  return expression instanceof LiteralMap;
 }
 
 export function isConditionalExpression(


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [X] The commit message follows our guidelines: https://github.com/ngneat/transloco/blob/master/CONTRIBUTING.md#commit
- [X] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

```
[ ] Bugfix
[X] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] Other... Please describe:
```

## What is the current behavior?

#114

## What is the new behavior?

Parse BindingPipe.args and LiteralMap.values.

For example following keys '68' and '69' are now detected.
```
{{ var | another : {foo: '68' | transloco} | other : ('69' | transloco) }}
```

## Does this PR introduce a breaking change?

```
[ ] Yes
[X] No
```

