### PR TITLE
Update path.utils.ts

### DIFF
--- a/src/utils/path.utils.ts
+++ b/src/utils/path.utils.ts
@@ -55,11 +55,7 @@ export function getScopeAndLangFromPath({
   return { scope, lang };
 }
 
-export function resolveConfigPaths(config: Config, sourceRoot: string) {
-  
-  if(!sourceRoot) {
-    sourceRoot = '';
-  }
+export function resolveConfigPaths(config: Config, sourceRoot = '') {
   
   const resolvePath = (configPath) =>
     path.resolve(process.cwd(), sourceRoot, configPath);

--- a/src/utils/path.utils.ts
+++ b/src/utils/path.utils.ts
@@ -56,6 +56,11 @@ export function getScopeAndLangFromPath({
 }
 
 export function resolveConfigPaths(config: Config, sourceRoot: string) {
+  
+  if(!sourceRoot) {
+    sourceRoot = '';
+  }
+  
   const resolvePath = (configPath) =>
     path.resolve(process.cwd(), sourceRoot, configPath);
   config.input = config.input.map(resolvePath);


### PR DESCRIPTION
When 'sourceRoot' is 'undefined' path.resolve throw error 'throw new ERR_INVALID_ARG_TYPE(name, 'string', value);' // TypeError [ERR_INVALID_ARG_TYPE]: The "path" argument must be of type string. Received undefined
Test and cast in string now... :)

## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] The commit message follows our guidelines: https://github.com/ngneat/transloco/blob/master/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

```
[ ] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] Other... Please describe:
```

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: N/A

## What is the new behavior?

## Does this PR introduce a breaking change?

```
[ ] Yes
[ ] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information
