### PR TITLE
fix: undefined default scope translationPath

### DIFF
--- a/src/keys-detective/compare-keys-to-files.ts
+++ b/src/keys-detective/compare-keys-to-files.ts
@@ -74,7 +74,7 @@ export function compareKeysToFiles({
       result.push({
         keys,
         scope,
-        translationsPath,
+        translationPath: translationsPath,
         files: glob.sync(
           `${translationsPath}/${isGlobal ? '' : scope}/*.${fileFormat}`
         ),
@@ -86,7 +86,7 @@ export function compareKeysToFiles({
     for (const filePath of files) {
       const { lang } = getScopeAndLangFromPath({
         filePath,
-        translationsPath,
+        translationsPath: translationPath,
         fileFormat,
       });
       const translation = readFile(filePath, { parse: true });


### PR DESCRIPTION
Global scope was using the key translationsPath instead of
translationPath used by scoped array elements
This was causing an undefined when retrieving scope and lang from path

## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/ngneat/transloco/blob/master/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

```
[x] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] Other... Please describe:
```

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->
Cannot read properties of undefined (reading 'split') from translationPath after upgrading to Transloco 4.0.0

Issue Number: #136

## What is the new behavior?

Correctly executing the command

## Does this PR introduce a breaking change?

```
[ ] Yes
[x] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information
