### PR TITLE
fix: added a glob ignore to the `resolveProjectBasePath`

### DIFF
--- a/src/utils/resolve-project-base-path.ts
+++ b/src/utils/resolve-project-base-path.ts
@@ -45,7 +45,9 @@ export function resolveProjectBasePath(projectName?: string): {
   let projectPath = '';
 
   if (projectName) {
-    projectPath = glob.sync(`**/${projectName}`)[0];
+    projectPath = glob.sync(`**/${projectName}`, {
+			ignore: ['node_modules/**', 'tmp/**', 'coverage/**', 'dist/**']
+		})[0];
   }
 
   const angularConfig = searchConfig(angularConfigFile, projectPath);


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [x ] The commit message follows our guidelines: https://github.com/ngneat/transloco/blob/master/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

```
[x ] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] Other... Please describe:
```

## What is the current behavior?
If a project called `foo` would have been build/tested it could be that a folder exist under
- `tmp/foo`
- `dist/foo`
- `coverage/foo`

then it might resolve it to `tmp/foo` instead, while we want to find the folder in a directory like: `apps/foo`, `libs/foo`, or `packages/foo` depending on file structure of the workspace.

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: #149

## What is the new behavior?
Don't glob the whole file tree, but ignore `node_modules`, `tmp`, `dist`, `coverage`

node_modules for obvious reasons for performance, other directories because it might resolve the project root wrong.

## Does this PR introduce a breaking change?

```
[ ] Yes
[x ] No

