### PR TITLE
fix: extractKeys could not find any files with backslashes

### DIFF
--- a/package.json
+++ b/package.json
@@ -94,6 +94,7 @@
     "@types/flat": "5.0.2",
     "@types/gettext-parser": "4.0.1",
     "@types/jest": "27.0.1",
+    "@types/glob": "^8.1.0",
     "cross-env": "7.0.3",
     "git-cz": "4.7.0",
     "husky": "7.0.4",

--- a/src/keys-builder/utils/extract-keys.ts
+++ b/src/keys-builder/utils/extract-keys.ts
@@ -1,5 +1,3 @@
-import glob from 'glob';
-
 import {
   Config,
   ExtractionResult,
@@ -8,6 +6,7 @@ import {
 } from '../../types';
 import { initExtraction } from '../../utils/init-extraction';
 import { devlog } from '../../utils/logger';
+import { normalizedGlob } from '../../utils/normalize-glob-path';
 
 export function extractKeys(
   { input, scopes, defaultValue, files }: Config,
@@ -16,8 +15,9 @@ export function extractKeys(
 ): ExtractionResult {
   let { scopeToKeys } = initExtraction();
 
+
   const fileList =
-    files || input.map((path) => glob.sync(`${path}/**/*.${fileType}`)).flat();
+    files || input.map((path) => normalizedGlob(`${path}/**/*.${fileType}`)).flat();
 
   for (const file of fileList) {
     devlog('extraction', 'Extracting keys', { file, fileType });

--- a/src/keys-detective/compare-keys-to-files.ts
+++ b/src/keys-detective/compare-keys-to-files.ts
@@ -1,7 +1,6 @@
 import { getGlobalConfig } from '@ngneat/transloco-utils';
 import { applyChange, diff } from 'deep-diff';
 import { flatten } from 'flat';
-import glob from 'glob';
 
 import { messages } from '../messages';
 import { Config, ScopeMap } from '../types';
@@ -11,6 +10,7 @@ import { getScopeAndLangFromPath } from '../utils/path.utils';
 
 import { buildTable } from './build-table';
 import { getTranslationFilesPath } from './get-translation-files-path';
+import { normalizedGlob } from '../utils/normalize-glob-path';
 
 interface Result {
   keys: Record<string, string>;
@@ -60,7 +60,7 @@ export function compareKeysToFiles({
       };
       result.push({
         ...res,
-        files: glob.sync(`${res.baseFilesPath}/*.${fileFormat}`),
+        files: normalizedGlob(`${res.baseFilesPath}/*.${fileFormat}`),
       });
     }
   }
@@ -87,7 +87,7 @@ export function compareKeysToFiles({
       };
       result.push({
         ...res,
-        files: glob.sync(
+        files: normalizedGlob(
           `${res.baseFilesPath}/${isGlobal ? '' : scope}/*.${fileFormat}`
         ),
       });

--- a/src/keys-detective/get-translation-files-path.ts
+++ b/src/keys-detective/get-translation-files-path.ts
@@ -1,10 +1,9 @@
-import glob from 'glob';
-
 import { FileFormats } from '../types';
+import { normalizedGlob } from '../utils/normalize-glob-path';
 
 export function getTranslationFilesPath(
   path: string,
   fileFormat: FileFormats
 ): string[] {
-  return glob.sync(`${path}/**/*.${fileFormat}`);
+  return normalizedGlob(`${path}/**/*.${fileFormat}`);
 }

--- a/src/utils/normalize-glob-path.ts
+++ b/src/utils/normalize-glob-path.ts
@@ -1,0 +1,15 @@
+import glob, { IOptions as globOptions } from 'glob';
+
+export function normalizedGlob(path: string, options: globOptions = {}) {
+  // on windows system the path will have `\` which are used a escape characters in glob
+  // therefore we have to escape those for the glob to work correctly on those systems
+  const normalizedPath = path.replace(/\\/g, '/');
+  const mergedOptions: globOptions = {
+    ... options,
+    ignore: [
+      'node_modules/**', 'tmp/**', 'coverage/**', 'dist/**'
+    ]
+  }
+  
+  return glob.sync(normalizedPath, mergedOptions);
+}

--- a/src/utils/resolve-project-base-path.ts
+++ b/src/utils/resolve-project-base-path.ts
@@ -1,6 +1,5 @@
 import chalk from 'chalk';
 import { cosmiconfigSync } from 'cosmiconfig';
-import glob from 'glob';
 import path from 'path';
 
 import { ProjectType } from '../config';
@@ -8,6 +7,7 @@ import { ProjectType } from '../config';
 import { coerceArray } from './collection.utils';
 import { jsoncParser } from './json.utils';
 import { isString } from './validators.utils';
+import { normalizedGlob } from './normalize-glob-path';
 
 const angularConfigFile = ['angular.json', '.angular.json'];
 const workspaceConfigFile = 'workspace.json';
@@ -45,7 +45,7 @@ export function resolveProjectBasePath(projectName?: string): {
   let projectPath = '';
 
   if (projectName) {
-    projectPath = glob.sync(`**/${projectName}`)[0];
+    projectPath = normalizedGlob(`**/${projectName}`)[0];
   }
 
   const angularConfig = searchConfig(angularConfigFile, projectPath);

--- a/src/utils/update-scopes-map.ts
+++ b/src/utils/update-scopes-map.ts
@@ -1,5 +1,4 @@
 import { tsquery } from '@phenomnomnominal/tsquery';
-import glob from 'glob';
 import {
   StringLiteral,
   ObjectLiteralExpression,
@@ -14,6 +13,7 @@ import { Scopes } from '../types';
 import { coerceArray } from './collection.utils';
 import { readFile } from './file.utils';
 import { toCamelCase } from './string.utils';
+import { normalizedGlob } from './normalize-glob-path';
 
 interface ScopeDef {
   scope?: string;
@@ -65,7 +65,7 @@ export function updateScopesMap({
   files?: string[];
 }): Scopes['aliasToScope'] {
   const tsFiles =
-    files || input.map((path) => glob.sync(`${path}/**/*.ts`)).flat();
+    files || input.map((path) => normalizedGlob(`${path}/**/*.ts`)).flat();
   // Return only the new scopes (for the plugin)
   const aliasToScope = {};
 


### PR DESCRIPTION
this change makes it so every backslash is replaced with a slash like on unix/linux systems. glob on window system did not output any files with backslashes with this change it makes sure that the file path is as expected

## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/ngneat/transloco/blob/master/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

```
[x ] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] Other... Please describe:
```

## What is the current behavior?
When having a file directory as input to the extractKeys like `'E:/Frontend/libs/booking/feature-booking-actions/src/lib/`

The glob would result in no files being found :(

```
- Extracting Template and Component Keys � test
√ Extracting Template and Component Keys �
ℹ 0 keys were found in 0 file.
```
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->


Issue Number: N/A

## What is the new behavior?
With changing the backslashes before putting it into the glob.sync, we start to find the correct files again :D
```
√ Extracting Template and Component Keys �
ℹ 226 keys were found in 89 files.
```

## Does this PR introduce a breaking change?

```
[ ] Yes
[x ] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information
