### PR TITLE
fix: only seach ts files for scopes

### DIFF
--- a/src/webpack-plugin/webpack-plugin.ts
+++ b/src/webpack-plugin/webpack-plugin.ts
@@ -51,7 +51,7 @@ export class TranslocoExtractKeysWebpackPlugin {
       if (keysExtractions.html.length || keysExtractions.ts.length) {
         if (keysExtractions.ts.length) {
           // Maybe someone added a TRANSLOCO_SCOPE
-          const newScopes = updateScopesMap({ files });
+          const newScopes = updateScopesMap({ files: keysExtractions.ts });
 
           const paths = buildScopeFilePaths({
             aliasToScope: newScopes,


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [X] The commit message follows our guidelines: https://github.com/ngneat/transloco/blob/master/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

Fix scopes extraction in cases where webpack emits a folder.

```
[X] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] Other... Please describe:
```

## What is the current behavior?

It appears in some situations webpack emits folders in the `files` array.
The files array is passed directly to the the `updateScopesMap` function.
This leads webpack to crash when it's trying to be read.

```
Error: EISDIR: illegal operation on a directory, read
```

Issue Number: N/A

## What is the new behavior?

Only *.ts files are passed to the `updateScopesMap` function as `files`.

## Does this PR introduce a breaking change?

```
[ ] Yes
[X] No
```

## Other information
